### PR TITLE
docs: update jsx to showcase custom events

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -143,9 +143,9 @@ children are appended, but **before** the `jsx` function returns.
 ```tsx
 <Gtk.Stack $={(self) => print(self, "is about to be returned")} />
 ```
+Below are a few common use cases for this function:
 
-The most common use case is to acquire a reference to the widget in the scope of
-the function.
+Acquire a reference to the widget in the scope of the function:
 
 ```tsx
 function MyWidget() {
@@ -159,7 +159,7 @@ function MyWidget() {
 }
 ```
 
-Another common use case is to initialize relations between widgets in the tree.
+Initialize relations between widgets in the tree:
 
 ```tsx
 function MyWidget() {
@@ -176,6 +176,36 @@ function MyWidget() {
       </Gtk.SearchBar>
     </Gtk.Window>
   )
+}
+```
+
+Adding event controllers to widgets after construction: 
+```tsx
+function MyWidget() {
+  const scrollCtrl = new Gtk.EventControllerScroll({
+    flags: Gtk.EventControllerScrollFlags.VERTICAL,
+  });
+  scrollCtrl.connect("scroll", (_ctrl, dx, dy) => {
+    // dy < 0 is wheel-up, dy > 0 is wheel-down
+    if (dy < 0) console.log("Scrolled up");
+    else if (dy > 0) console.log("Scrolled down");
+  });
+
+  const clickCtrl = new Gtk.GestureClick();
+  clickCtrl.connect("released", () => {
+    console.log("Clicked");
+  });
+
+  return (
+    <box
+      $={(w) => {
+        w.add_controller(clickCtrl);
+        w.add_controller(scrollCtrl);
+      }}
+    >
+      <label label={"Scroll/Click on me!"} />
+    </box>
+  );
 }
 ```
 


### PR DESCRIPTION
I was rewriting my v1 ags shell using v3 and wanted to implement the same behavior for "scrolling over volume indicator" in Aylur's v1 dotfiles. As of now I settled on doing it using the setup function and I think it's a good showcase of how handy this function can be.


This probably needs another discussion but a "ref" similar to how it's done in react could ease these kind of workflows. The naivest thing that comes to my mind is to run a set of "pre-setup" assignments before executing the actual contents of the setup function. But I know next to nothing about Gnim's internals, so this might not be feasible. Also there's emphasis on how Gnim is not react so this could give the wrong ideas.